### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,6 +4,9 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/vadimfilimonov/React-TODO/security/code-scanning/4](https://github.com/vadimfilimonov/React-TODO/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs read-only operations (e.g., checking out the repository and running a linter), the `contents: read` permission is sufficient. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
